### PR TITLE
Added option to see token usage using --token-usage or -t #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Options:
   
   -a, --append        whether it destructively writes to file or appends ot
                                                     [boolean] [default: "false"]
+   
+  -t, --token-usage   provides token usage information at the end of output
                                                     
   -v, --version       version showing                                  [boolean]
   


### PR DESCRIPTION
When user uses the option --token-usage or -t, it gives them information about the total tokens used as well the tokens used for the prompt and the response.

![image](https://github.com/user-attachments/assets/c187f641-feb0-4eeb-afe5-ae58f04b1735)
